### PR TITLE
add CMakeLists.txt for ESP-IDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRCS "src/bme68x/bme68x.c" "src/bme68xLibrary.cpp"
+    INCLUDE_DIRS "." "src" "src/bme68x"
+)


### PR DESCRIPTION
The CMakeLists.txt makes it possible to use the library with pure ESP-IDF.